### PR TITLE
Fixes #4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 allprojects {
-    version = "1.0.0-alpha03"
+    version = "1.0.0-alpha04"
     group = "com.github.yanneckreiss.kconmapper"
 
     repositories {

--- a/kconmapper-ksp/src/main/kotlin/de/yanneckreiss/kconmapper/processor/KCMSymbolProcessor.kt
+++ b/kconmapper-ksp/src/main/kotlin/de/yanneckreiss/kconmapper/processor/KCMSymbolProcessor.kt
@@ -24,10 +24,9 @@ class KCMSymbolProcessor(
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val annotationPackagePath = "$KCONMAPPER_PACKAGE_NAME.$KCONMAPPER_ANNOTATIONS_PACKAGE_NAME.$KCONMAPPER_ANNOTATION_NAME"
-        val symbols: Sequence<KSAnnotated> = resolver.getSymbolsWithAnnotation(annotationName = annotationPackagePath)
-        val ret: List<KSAnnotated> = symbols.filter { ksAnnotated -> !ksAnnotated.validate() }.toList()
+        val resolvedSymbols: Sequence<KSAnnotated> = resolver.getSymbolsWithAnnotation(annotationName = annotationPackagePath)
 
-        symbols
+        resolvedSymbols
             .filter { ksAnnotated -> ksAnnotated is KSClassDeclaration && ksAnnotated.validate() }
             .forEach { ksAnnotated: KSAnnotated ->
                 val classDeclaration: KSClassDeclaration = (ksAnnotated as KSClassDeclaration)
@@ -51,6 +50,6 @@ class KCMSymbolProcessor(
                 }
             }
 
-        return ret
+        return emptyList()
     }
 }

--- a/kconmapper-ksp/src/main/kotlin/de/yanneckreiss/kconmapper/processor/generator/MappingFunctionGenerator.kt
+++ b/kconmapper-ksp/src/main/kotlin/de/yanneckreiss/kconmapper/processor/generator/MappingFunctionGenerator.kt
@@ -26,7 +26,7 @@ class MappingFunctionGenerator(
      *
      * @param targetClass The class we want to map to.
      *        It defines the schema which the `sourceClass` properties should be mapped to.
-     *        Therefore is also the return type of the mapper extension function.
+     *        Therefore, it is also the return type of the mapper extension function.
      *
      * @param sourceClass The class which is the source for properties we want to map to the constructor of the
      *        target class. It is therefore at the same time the class for which we generate the extension function.
@@ -37,16 +37,16 @@ class MappingFunctionGenerator(
         packageImports: PackageImports
     ): String {
 
-        val targetClassName = targetClass.simpleName.getShortName()
-        val packageName = targetClass.containingFile!!.packageName.asString()
+        val targetClassName: String = targetClass.simpleName.getShortName()
+        val packageName: String = targetClass.packageName.asString()
         val targetClassTypeParameters: List<KSTypeParameter> = targetClass.typeParameters
 
         packageImports.targetClassTypeParameters += targetClassTypeParameters
 
-        // Add import for the target class = class we want to map to via extension functions
+        // Add import for the target class
         packageImports.addImport(packageName, targetClassName)
 
-        // Add import for source classe
+        // Add import for source class
         packageImports.addImport(sourceClass.packageName.asString(), sourceClass.simpleName.asString())
 
         // Create mapping extension function for source class to target class
@@ -259,11 +259,13 @@ class MappingFunctionGenerator(
             // Search for any matching fields, also considers fields of supertype
             sourceClass.getAllProperties().forEach { parameterFromSourceClass: KSPropertyDeclaration ->
                 val parameterNameFromSourceClass: String = parameterFromSourceClass.simpleName.asString()
-                val aliases: ArrayList<String>? = parameterFromSourceClass.annotations
+
+                // Get the aliases from the KConMapperProperty annotation, can in reality only be of type ArrayList<String>?
+                val aliases: ArrayList<*>? = parameterFromSourceClass.annotations
                     .firstOrNull { ksAnnotation -> ksAnnotation.shortName.asString() == KCONMAPPER_PROPERTY_ANNOTATION_NAME }
                     ?.arguments
                     ?.firstOrNull()
-                    ?.value as? ArrayList<String>
+                    ?.value as ArrayList<*>?
 
                 // The argument matches if either the actual name or the alias from the KConMapperProperty annotation is the same
                 if ((parameterNameFromSourceClass == valueName) || (aliases?.any { alias -> alias == valueName } == true)) {
@@ -425,11 +427,11 @@ class MappingFunctionGenerator(
         val sourceClassName: String = sourceClass.getName()
         val targetClassName: String = targetClass.getName()
 
-        val sourceClassType: String = sourceClass.typeParameters.firstOrNull()?.let { ksTypeParameter: KSTypeParameter ->
+        val sourceClassType: String = sourceClass.typeParameters.firstOrNull()?.let KsTypeParameterLet@ { ksTypeParameter: KSTypeParameter ->
 
-            val upperBound = ksTypeParameter.bounds.firstOrNull()?.resolve()?.let { upperBoundType ->
+            val upperBound = ksTypeParameter.bounds.firstOrNull()?.resolve()?.let UpperBoundLet@{ upperBoundType ->
                 packageImports.addImport(upperBoundType)
-                return@let upperBoundType.getName()
+                return@UpperBoundLet upperBoundType.getName()
             } ?: ""
 
             DIAMOND_OPERATOR_OPEN + upperBound + DIAMOND_OPERATOR_CLOSE

--- a/kconmapper-ksp/src/main/kotlin/de/yanneckreiss/kconmapper/processor/visitor/KCMVisitor.kt
+++ b/kconmapper-ksp/src/main/kotlin/de/yanneckreiss/kconmapper/processor/visitor/KCMVisitor.kt
@@ -39,12 +39,7 @@ class KCMVisitor(
 ) : KSVisitorVoid() {
 
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
-        classDeclaration.primaryConstructor!!.accept(this, data)
-    }
-
-    override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
-
-        val annotatedClass: KSClassDeclaration = function.parentDeclaration as KSClassDeclaration
+        val annotatedClass: KSClassDeclaration = classDeclaration
         val kcmAnnotation: KSAnnotation = extractKCMAnnotation(annotatedClass)
         val mapFromClasses: List<KSClassDeclaration> = extractArgumentClasses(kcmAnnotation, KCONMAPPER_FROM_CLASSES_ANNOTATION_ARG_NAME)
         val mapToClasses: List<KSClassDeclaration> = extractArgumentClasses(kcmAnnotation, KCONMAPPER_TARGET_CLASSES_ANNOTATION_ARG_NAME)
@@ -84,11 +79,15 @@ class KCMVisitor(
         }
 
         generateCode(
-            containingFile = function.containingFile!!,
+            containingFile = classDeclaration.containingFile!!,
             targetClassName = annotatedClass.simpleName.getShortName(),
             packageImports = packageImports,
             extensionFunctions = extensionFunctions
         )
+    }
+
+    override fun visitAnnotation(annotation: KSAnnotation, data: Unit) {
+        annotation.annotationType.resolve().declaration.accept(this, data)
     }
 
     private fun generateCode(


### PR DESCRIPTION
- Resolve targetClass package name by KSClassDeclaration directly instead of the containing file to avoid resolving clashes when referencing classes from another module
- Optimized annotation processing
- Refactoring